### PR TITLE
gemspec: Add basic summary, homepage

### DIFF
--- a/matrix.gemspec
+++ b/matrix.gemspec
@@ -6,9 +6,9 @@ Gem::Specification.new do |spec|
   spec.authors       = ["SHIBATA Hiroshi"]
   spec.email         = ["hsbt@ruby-lang.org"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = %q{An implementation of Matrix and Vector classes.}
+  spec.description   = %q{An implementation of Matrix and Vector classes.}
+  spec.homepage      = "https://github.com/ruby/matrix"
   spec.license       = "BSD-2-Clause"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
This PR adds a basic summary and description and a homepage URL.

This makes the gemspec valid. (Before this change, it was not possible to run the `bin/setup` to bundle install this gem.)