### PR TITLE
Add version and default gem badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Matrix
+# Matrix [![Version](https://badge.fury.io/rb/matrix.svg)](https://badge.fury.io/rb/matrix) [![Default Gem](https://img.shields.io/badge/stdgem-default-9c1260.svg)](https://stdgems.org/matrix/)
 
 An implementation of `Matrix` and `Vector` classes.
 


### PR DESCRIPTION
A suggestion to add a few badges:

- One badge displays most recent gem version and links to rubygems.org
- The other badge mentions its a default gem and links to its stdgems.org page for more info

We could also add a travis badge once travis is setup. The markup would be:

    [!Travis(https://travis-ci.org/ruby/matrix.svg)](https://travis-ci.org/ruby/matrix)