### PR TITLE
Extend get_element to support ranges

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -295,11 +295,25 @@ class Matrix
     self.class.send(:new, rows, column_count) # bypass privacy of Matrix.new
   end
 
+  ## :call-seq:
+  #   matrix[range, range] -> matrix
+  #   matrix[range, integer] -> vector
+  #   matrix[integer, range] -> vector
+  #   matrix[integer, integer] -> element
   #
-  # Returns element (+i+,+j+) of the matrix.  That is: row +i+, column +j+.
-  #
+  # Returns element or elements of the matrix.
   def [](i, j)
-    @rows.fetch(i){return nil}[j]
+    rows = check_range(i, :row) or row = check_int(i, :row)
+    columns = check_range(j, :column) or column = check_int(j, :column)
+    if rows && columns
+      @rows[rows].map{ |row| row[columns] }
+    elsif rows
+      @rows[rows].map{ |row| row[column] }
+    elsif columns
+      self.row(row)[columns]
+    else
+      self.row(row)[column]
+    end
   end
   alias element []
   alias component []

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -634,6 +634,16 @@ class TestMatrix < Test::Unit::TestCase
     assert_equal Matrix.empty(0,3), Matrix.combine(Matrix.empty(0,3), Matrix.empty(0,3)) { raise }
   end
 
+  def test_get_element
+    m = Matrix[[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    assert_equal(m[0..1, 1..2], [[2, 3], [5, 6]])
+    assert_equal(m[0..1, 0..], [[1, 2, 3], [4, 5, 6]])
+    assert_equal(m[0..1, 1], [2, 5])
+    assert_equal(m[2, 1..2], [8, 9])
+    assert_equal(m[2, 1], 8)
+    assert_raise(IndexError) { m[1.., 7] }
+  end
+
   def test_set_element
     src = Matrix[
       [1, 2, 3, 4],


### PR DESCRIPTION
This is the missing part of https://github.com/ruby/ruby/pull/1905
Now we are able to get elements of matrix using ranges. I used parts of `set_element` implementation so if a range or index is outside of matrix `IndexError` is raised.