### PR TITLE
fix :unitary? and add :adjoint

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -827,6 +827,16 @@ class Matrix
   end
   alias_method :cofactor_expansion, :laplace_expansion
 
+  #
+  # Returns the adjoint of the matrix.
+  #
+  #   Matrix[ [i,1],[2,-i] ].adjoint
+  #   #  => -i 2
+  #   #      1 i
+  #
+  def adjoint
+    conjugate.transpose
+  end
 
   #--
   # TESTING -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
@@ -984,11 +994,13 @@ class Matrix
   #
   def unitary?
     raise ErrDimensionMismatch unless square?
-    rows.each_with_index do |row, i|
+    adj_conj = adjoint
+
+    row_count.times do |i|
       column_count.times do |j|
         s = 0
         row_count.times do |k|
-          s += row[k].conj * rows[k][j]
+          s += adj_conj[i, k] * self[k, j]
         end
         return false unless s == (i == j ? 1 : 0)
       end

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -360,6 +360,20 @@ class TestMatrix < Test::Unit::TestCase
     assert_raise(RuntimeError) { Matrix.empty(0, 0).laplace_expansion(row: 0) }
   end
 
+  def test_adjoint
+    assert_equal(Matrix.empty, Matrix.empty.adjoint)
+    assert_equal(Matrix[[1]], Matrix[[1]].adjoint)
+    assert_equal(Matrix[[9,-6],[-3,7]], Matrix[[9,-3],[-6,7]].adjoint)
+    assert_equal(Matrix[[45,3,-7],[6,-1,0],[-7,0,0]], Matrix[[45,6,-7],[3,-1,0],[-7,0,0]].adjoint)
+    assert_equal(@m1.transpose, @m1.adjoint)
+    assert_equal(@m4.transpose, @m4.adjoint)
+    assert_equal(Matrix[[Complex(1,-2),1], [Complex(0,-1), 2], [0,3]], @c1.adjoint)
+    assert_equal(@e1.transpose, @e1.adjoint)
+    assert_equal(@e2.transpose, @e2.adjoint)
+    assert_equal(Matrix[[0,Complex(0,1)], [Complex(0, -1), 0]], Matrix[[0,Complex(0,1)], [Complex(0, -1), 0]].adjoint)
+    assert_equal(Matrix[[Complex(0,1), 0], [0, Complex(0,-1)]], Matrix[[Complex(0, -1), 0], [0, Complex(0, 1)]].adjoint)
+  end
+
   def test_regular?
     assert(Matrix[[1, 0], [0, 1]].regular?)
     assert(Matrix[[1, 0, 0], [0, 1, 0], [0, 0, 1]].regular?)
@@ -377,6 +391,15 @@ class TestMatrix < Test::Unit::TestCase
     assert(Matrix[[1, 0, 0], [0, 1, 0], [0, 0, 1]].square?)
     assert(Matrix[[1, 0, 0], [0, 0, 1], [0, 0, 1]].square?)
     assert(!Matrix[[1, 0, 0], [0, 1, 0]].square?)
+  end
+
+  def test_unitary?
+    assert(Matrix[[0,1], [1,0]].unitary?)
+    assert(Matrix[[0,Complex(0,-1)], [Complex(0,1),0]].unitary?)
+    assert(Matrix[[1,0], [0, -1]].unitary?)
+    assert(!Matrix[[1,1], [1,1]].unitary?)
+    assert(Matrix[[1,0,0,0], [0,0,1,0], [0,1,0,0], [0,0,0,1]].unitary?)
+    assert(Matrix[[1,0,0,0], [0,1,0,0], [0,0,0,1], [0,0,1,0]].unitary?)
   end
 
   def test_mul


### PR DESCRIPTION
`:unitary?` is currently not working(since 2011?). Also added tests.

Example:
```
require 'matrix'
Matrix[[0, Complex(0,-1)], [Complex(0,1),0]].unitary? # false, should be true
```
[Verification of unitary matrix](https://www.wolframalpha.com/input/?i=unitary+%5B%5B0%2C+i%5D%2C+%5B-i%2C+0%5D%5D)