### PR TITLE
Implement Matrix#rotate_entries

### DIFF
--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1449,42 +1449,39 @@ class Matrix
   #   #  => Matrix[[3, 1], [4, 2]]
   #
   def rotate_entries(quarter_turns=:clockwise)
+    if quarter_turns.is_a? Integer
+      quarter_turns = case quarter_turns % 4
+        when 0
+          :dup
+        when 1
+          :clockwise
+        when 2
+          :half_turn
+        when 3
+          :counter_clockwise
+        end
+    end
+
     if empty?
       case quarter_turns
       when :clockwise, :counter_clockwise
-        return Matrix.empty(column_count, row_count) if quarter_turns
-      when :half_turn
+        return Matrix.empty(column_count, row_count)
+      when :half_turn, :dup
         return Matrix.empty(row_count, column_count)
-      when Numeric
-        case quarter_turns % 4
-        when 0, 2
-          return self.dup
-        when 1, 3
-          return rotate_entries(:clockwise)
-        end
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
       end
     end
 
     case quarter_turns
+      when :dup
+        self.dup
       when :clockwise
         Matrix[*column_vectors.map{|c| c.to_a.reverse}]
       when :counter_clockwise
         Matrix[*column_vectors.map{|c| c}.reverse]
       when :half_turn
         Matrix[*row_vectors.map{|c| c.to_a.reverse}.reverse]
-      when Numeric
-        case quarter_turns % 4
-        when 0
-          self.dup
-        when 1
-          rotate_entries(:clockwise)
-        when 2
-          rotate_entries(:half_turn)
-        when 3
-          rotate_entries(:counter_clockwise)
-        end
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
     end

--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1445,6 +1445,23 @@ class Matrix
   # * :half_turn: first row becomes last row, elements in reverse order
   #
   def rotate_entries(quarter_turns: :clockwise)
+    if empty?
+      case quarter_turns
+      when :clockwise, :counter_clockwise
+        return Matrix.empty(column_count, row_count) if quarter_turns
+      when :half_turn
+        return Matrix.empty(row_count, column_count)
+      when Numeric
+        # % 4 == 0 -> dup
+        # % 4 == 1 -> clockwise
+        # % 4 == 2 -> half_turn
+        # % 4 == 3 -> counter_clockwise
+        raise "Not yet implemented"
+      else
+        raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
+      end
+    end
+
     case quarter_turns
       when :clockwise
         Matrix[*column_vectors.map{|c| c.to_a.reverse}]
@@ -1453,6 +1470,10 @@ class Matrix
       when :half_turn
         Matrix[*row_vectors.map{|c| c.to_a.reverse}.reverse]
       when Numeric
+        # % 4 == 0 -> dup
+        # % 4 == 1 -> clockwise
+        # % 4 == 2 -> half_turn
+        # % 4 == 3 -> counter_clockwise
         raise "Not yet implemented"
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"

--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1452,11 +1452,12 @@ class Matrix
       when :half_turn
         return Matrix.empty(row_count, column_count)
       when Numeric
-        # % 4 == 0 -> dup
-        # % 4 == 1 -> clockwise
-        # % 4 == 2 -> half_turn
-        # % 4 == 3 -> counter_clockwise
-        raise "Not yet implemented"
+        case quarter_turns % 4
+        when 0, 2
+          return self.dup
+        when 1, 3
+          return rotate_entries(quarter_turns: :clockwise)
+        end
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
       end
@@ -1470,11 +1471,16 @@ class Matrix
       when :half_turn
         Matrix[*row_vectors.map{|c| c.to_a.reverse}.reverse]
       when Numeric
-        # % 4 == 0 -> dup
-        # % 4 == 1 -> clockwise
-        # % 4 == 2 -> half_turn
-        # % 4 == 3 -> counter_clockwise
-        raise "Not yet implemented"
+        case quarter_turns % 4
+        when 0
+          self.dup
+        when 1
+          rotate_entries(quarter_turns: :clockwise)
+        when 2
+          rotate_entries(quarter_turns: :half_turn)
+        when 3
+          rotate_entries(quarter_turns: :counter_clockwise)
+        end
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
     end

--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1444,6 +1444,10 @@ class Matrix
   #   (but with elements in reverse order)
   # * :half_turn: first row becomes last row, elements in reverse order
   #
+  #   m = Matrix[ [1, 2], [3, 4] ]
+  #   r = m.rotate_entries(quarter_turns: :clockwise)
+  #   #  => Matrix[[3, 1], [4, 2]]
+  #
   def rotate_entries(quarter_turns: :clockwise)
     if empty?
       case quarter_turns

--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1445,10 +1445,10 @@ class Matrix
   # * :half_turn: first row becomes last row, elements in reverse order
   #
   #   m = Matrix[ [1, 2], [3, 4] ]
-  #   r = m.rotate_entries(quarter_turns: :clockwise)
+  #   r = m.rotate_entries(:clockwise)
   #   #  => Matrix[[3, 1], [4, 2]]
   #
-  def rotate_entries(quarter_turns: :clockwise)
+  def rotate_entries(quarter_turns=:clockwise)
     if empty?
       case quarter_turns
       when :clockwise, :counter_clockwise
@@ -1460,7 +1460,7 @@ class Matrix
         when 0, 2
           return self.dup
         when 1, 3
-          return rotate_entries(quarter_turns: :clockwise)
+          return rotate_entries(:clockwise)
         end
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
@@ -1479,11 +1479,11 @@ class Matrix
         when 0
           self.dup
         when 1
-          rotate_entries(quarter_turns: :clockwise)
+          rotate_entries(:clockwise)
         when 2
-          rotate_entries(quarter_turns: :half_turn)
+          rotate_entries(:half_turn)
         when 3
-          rotate_entries(quarter_turns: :counter_clockwise)
+          rotate_entries(:counter_clockwise)
         end
       else
         raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"

--- a/lib/matrix.rb
+++ b/lib/matrix.rb
@@ -1435,6 +1435,30 @@ class Matrix
     rank
   end
 
+  #
+  # Returns a new matrix where elements are rotated.
+  # The +quarter_turns+ option defines the direction of the rotation (defaults
+  # to :clockwise):
+  # * :clockwise: "turn right" - first row becomes last column
+  # * :counter_clockwise: "turn left" - first row becomes first column
+  #   (but with elements in reverse order)
+  # * :half_turn: first row becomes last row, elements in reverse order
+  #
+  def rotate_entries(quarter_turns: :clockwise)
+    case quarter_turns
+      when :clockwise
+        Matrix[*column_vectors.map{|c| c.to_a.reverse}]
+      when :counter_clockwise
+        Matrix[*column_vectors.map{|c| c}.reverse]
+      when :half_turn
+        Matrix[*row_vectors.map{|c| c.to_a.reverse}.reverse]
+      when Numeric
+        raise "Not yet implemented"
+      else
+        raise ArgumentError, "expected #{quarter_turns.inspect} to be one of :clockwise, :counter_clockwise, :half_turn or an integer (assuming clockwise rotation)"
+    end
+  end
+
   # Returns a matrix with entries rounded to the given precision
   # (see Float#round)
   #

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -824,57 +824,57 @@ class TestMatrix < Test::Unit::TestCase
 
   def test_rotate_with_symbol
     assert_equal(Matrix[[4, 1], [5, 2], [6, 3]], @m1.rotate_entries)
-    assert_equal(@m1.rotate_entries, @m1.rotate_entries(quarter_turns: :clockwise))
+    assert_equal(@m1.rotate_entries, @m1.rotate_entries(:clockwise))
     assert_equal(Matrix[[4, 1], [5, 2], [6, 3]],
-                 @m1.rotate_entries(quarter_turns: :clockwise))
+                 @m1.rotate_entries(:clockwise))
     assert_equal(Matrix[[3, 6], [2, 5], [1, 4]],
-                 @m1.rotate_entries(quarter_turns: :counter_clockwise))
+                 @m1.rotate_entries(:counter_clockwise))
     assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
-                 @m1.rotate_entries(quarter_turns: :half_turn))
+                 @m1.rotate_entries(:half_turn))
     assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
-                 @m1.rotate_entries(quarter_turns: :half_turn))
+                 @m1.rotate_entries(:half_turn))
     assert_equal(Matrix.empty(0,2),
-                 @e1.rotate_entries(quarter_turns: :clockwise))
+                 @e1.rotate_entries(:clockwise))
     assert_equal(Matrix.empty(0,2),
-                 @e1.rotate_entries(quarter_turns: :counter_clockwise))
+                 @e1.rotate_entries(:counter_clockwise))
     assert_equal(Matrix.empty(2,0),
-                 @e1.rotate_entries(quarter_turns: :half_turn))
+                 @e1.rotate_entries(:half_turn))
     assert_equal(Matrix.empty(0,3),
-                 @e2.rotate_entries(quarter_turns: :half_turn))
+                 @e2.rotate_entries(:half_turn))
   end
 
   def test_rotate_with_numeric
     assert_equal(Matrix[[4, 1], [5, 2], [6, 3]],
-                 @m1.rotate_entries(quarter_turns: 1))
-    assert_equal(@m2.rotate_entries(quarter_turns: :half_turn),
-                 @m2.rotate_entries(quarter_turns: 2))
-    assert_equal(@m2.rotate_entries(quarter_turns: :half_turn),
-                 @m1.rotate_entries(quarter_turns: 2))
-    assert_equal(@m1.rotate_entries(quarter_turns: :counter_clockwise),
-                 @m1.rotate_entries(quarter_turns: 3))
+                 @m1.rotate_entries(1))
+    assert_equal(@m2.rotate_entries(:half_turn),
+                 @m2.rotate_entries(2))
+    assert_equal(@m2.rotate_entries(:half_turn),
+                 @m1.rotate_entries(2))
+    assert_equal(@m1.rotate_entries(:counter_clockwise),
+                 @m1.rotate_entries(3))
     assert_equal(@m1,
-                 @m1.rotate_entries(quarter_turns: 4))
+                 @m1.rotate_entries(4))
     assert_equal(@m1,
-                 @m1.rotate_entries(quarter_turns: 4))
+                 @m1.rotate_entries(4))
     assert_not_same(@m1,
-                    @m1.rotate_entries(quarter_turns: 4))
-    assert_equal(@m1.rotate_entries(quarter_turns: :clockwise),
-                 @m1.rotate_entries(quarter_turns: 5))
+                    @m1.rotate_entries(4))
+    assert_equal(@m1.rotate_entries(:clockwise),
+                 @m1.rotate_entries(5))
     assert_equal(Matrix.empty(0,2),
-                 @e1.rotate_entries(quarter_turns: 1))
+                 @e1.rotate_entries(1))
     assert_equal(@e2,
-                 @e2.rotate_entries(quarter_turns: 2))
-    assert_equal(@e2.rotate_entries(quarter_turns: 1),
-                 @e2.rotate_entries(quarter_turns: 3))
-    assert_equal(@e2.rotate_entries(quarter_turns: :counter_clockwise),
-                 @e2.rotate_entries(quarter_turns: -1))
-    assert_equal(@m1.rotate_entries(quarter_turns: :counter_clockwise),
-                 @m1.rotate_entries(quarter_turns: -1))
+                 @e2.rotate_entries(2))
+    assert_equal(@e2.rotate_entries(1),
+                 @e2.rotate_entries(3))
+    assert_equal(@e2.rotate_entries(:counter_clockwise),
+                 @e2.rotate_entries(-1))
+    assert_equal(@m1.rotate_entries(:counter_clockwise),
+                 @m1.rotate_entries(-1))
     assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
-                 @m1.rotate_entries(quarter_turns: -2))
+                 @m1.rotate_entries(-2))
     assert_equal(@m1,
-                 @m1.rotate_entries(quarter_turns: -4))
-    assert_equal(@m1.rotate_entries(quarter_turns: -1),
-                 @m1.rotate_entries(quarter_turns: -5))
+                 @m1.rotate_entries(-4))
+    assert_equal(@m1.rotate_entries(-1),
+                 @m1.rotate_entries(-5))
   end
 end

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -866,5 +866,15 @@ class TestMatrix < Test::Unit::TestCase
                  @e2.rotate_entries(quarter_turns: 2))
     assert_equal(@e2.rotate_entries(quarter_turns: 1),
                  @e2.rotate_entries(quarter_turns: 3))
+    assert_equal(@e2.rotate_entries(quarter_turns: :counter_clockwise),
+                 @e2.rotate_entries(quarter_turns: -1))
+    assert_equal(@m1.rotate_entries(quarter_turns: :counter_clockwise),
+                 @m1.rotate_entries(quarter_turns: -1))
+    assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
+                 @m1.rotate_entries(quarter_turns: -2))
+    assert_equal(@m1,
+                 @m1.rotate_entries(quarter_turns: -4))
+    assert_equal(@m1.rotate_entries(quarter_turns: -1),
+                 @m1.rotate_entries(quarter_turns: -5))
   end
 end

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -822,7 +822,7 @@ class TestMatrix < Test::Unit::TestCase
     assert_same obj1, obj2
   end if defined?(Ractor)
 
-  def test_rotate
+  def test_rotate_with_symbol
     assert_equal(Matrix[[4, 1], [5, 2], [6, 3]], @m1.rotate_entries)
     assert_equal(@m1.rotate_entries, @m1.rotate_entries(quarter_turns: :clockwise))
     assert_equal(Matrix[[4, 1], [5, 2], [6, 3]],
@@ -839,5 +839,32 @@ class TestMatrix < Test::Unit::TestCase
                  @e1.rotate_entries(quarter_turns: :counter_clockwise))
     assert_equal(Matrix.empty(2,0),
                  @e1.rotate_entries(quarter_turns: :half_turn))
+    assert_equal(Matrix.empty(0,3),
+                 @e2.rotate_entries(quarter_turns: :half_turn))
+  end
+
+  def test_rotate_with_numeric
+    assert_equal(Matrix[[4, 1], [5, 2], [6, 3]],
+                 @m1.rotate_entries(quarter_turns: 1))
+    assert_equal(@m2.rotate_entries(quarter_turns: :half_turn),
+                 @m2.rotate_entries(quarter_turns: 2))
+    assert_equal(@m2.rotate_entries(quarter_turns: :half_turn),
+                 @m1.rotate_entries(quarter_turns: 2))
+    assert_equal(@m1.rotate_entries(quarter_turns: :counter_clockwise),
+                 @m1.rotate_entries(quarter_turns: 3))
+    assert_equal(@m1,
+                 @m1.rotate_entries(quarter_turns: 4))
+    assert_equal(@m1,
+                 @m1.rotate_entries(quarter_turns: 4))
+    assert_not_same(@m1,
+                    @m1.rotate_entries(quarter_turns: 4))
+    assert_equal(@m1.rotate_entries(quarter_turns: :clockwise),
+                 @m1.rotate_entries(quarter_turns: 5))
+    assert_equal(Matrix.empty(0,2),
+                 @e1.rotate_entries(quarter_turns: 1))
+    assert_equal(@e2,
+                 @e2.rotate_entries(quarter_turns: 2))
+    assert_equal(@e2.rotate_entries(quarter_turns: 1),
+                 @e2.rotate_entries(quarter_turns: 3))
   end
 end

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -821,4 +821,15 @@ class TestMatrix < Test::Unit::TestCase
     end.take
     assert_same obj1, obj2
   end if defined?(Ractor)
+
+  def test_rotate
+    assert_equal(Matrix[[4, 1], [5, 2], [6, 3]], @m1.rotate_entries)
+    assert_equal(@m1.rotate_entries, @m1.rotate_entries(quarter_turns: :clockwise))
+    assert_equal(Matrix[[4, 1], [5, 2], [6, 3]],
+                 @m1.rotate_entries(quarter_turns: :clockwise))
+    assert_equal(Matrix[[3, 6], [2, 5], [1, 4]],
+                 @m1.rotate_entries(quarter_turns: :counter_clockwise))
+    assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
+                 @m1.rotate_entries(quarter_turns: :half_turn))
+  end
 end

--- a/test/matrix/test_matrix.rb
+++ b/test/matrix/test_matrix.rb
@@ -831,5 +831,13 @@ class TestMatrix < Test::Unit::TestCase
                  @m1.rotate_entries(quarter_turns: :counter_clockwise))
     assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
                  @m1.rotate_entries(quarter_turns: :half_turn))
+    assert_equal(Matrix[[6, 5, 4], [3, 2, 1]],
+                 @m1.rotate_entries(quarter_turns: :half_turn))
+    assert_equal(Matrix.empty(0,2),
+                 @e1.rotate_entries(quarter_turns: :clockwise))
+    assert_equal(Matrix.empty(0,2),
+                 @e1.rotate_entries(quarter_turns: :counter_clockwise))
+    assert_equal(Matrix.empty(2,0),
+                 @e1.rotate_entries(quarter_turns: :half_turn))
   end
 end


### PR DESCRIPTION
As technically proposed by me and API given by @marcandre in #19 , this is a simple implementation of `Matrix#rotate_entries`.

I would be happy to have this feature as implemented and will not be able to throw much more time at the implementation, but a couple of considerations could be:

  * the method does always return a newly created Matrix instance. This seems to be the case for most if not all Matrix-methods. To pave way to more memory-efficient implementations, corresponding "bang"-methods (`m.rotate_entries!`) that modify the instance itself could be considered.
  * the implementation is not optimized for anything (besides time-of-implementation) and does some array-conversions that could possibly be eliminated.
  * the argument is a keyword-argument, and the keyword is a bit lenghty (`quarter_turns`). It would be easy to change that. Afaics keyword-arguments are not used in any other `Matrix` method, and these were "only" introduced in Ruby 2.0 (not an issue as `matrix` requires Ruby >= 2.5 anyways).
  * control-flow can be argued about (nested case/when and isolated empty-special case handling which could be extracted).
  
  Happy to hear more thoughts and even more happy if it gets merged :) .